### PR TITLE
add Verifier for pure quantum programs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,19 +59,20 @@ a generic circuit `Circuit` with the same name. A generic circuit is a generic q
 be overload with different Julia types, e.g
 
 ```jl
-@device function qft(l::Int, n::Int)
-    l => H
-    for k in l:n
-        @ctrl k l=>shift(2π/2^(k-l))
+@device function qft(n::Int)
+    1 => H
+    for k in 2:n
+        @ctrl k 1=>shift(2π/2^k)
     end
 
-    if n > l
-        l+1:n => qft(l+1, n)
+    if n > 1
+        2:n => qft(n-1)
     end
 end
-
-@device qft(n::Int) = 1:n => qft(1, n)
 ```
+
+**There is no need to worry about global position**: everything can be defined locally and we will infer the correct global location
+later either in compile time or runtime.
 
 note: all the quantum gates should be annotate with its corresponding locations, or the compiler will not
 treat it as a quantum gate but instead of the original Julia expression.

--- a/src/YaoIR.jl
+++ b/src/YaoIR.jl
@@ -10,6 +10,6 @@ include("runtime/primitives.jl")
 
 include("compiler/ir.jl")
 include("compiler/compiler.jl")
-
+include("compiler/verify.jl")
 
 end # module

--- a/src/compiler/compiler.jl
+++ b/src/compiler/compiler.jl
@@ -16,8 +16,51 @@ end
 JuliaAST() = JuliaAST(gensym(:register), gensym(:locs))
 CtrlJuliaAST() = CtrlJuliaAST(gensym(:register), gensym(:locations), gensym(:ctrl_locs))
 
+"""
+    @device [strict=false] <generic circuit definition>
+
+Entry for defining a generic quantum program. A generic quantum program is a function takes
+a set of classical arguments as input and return a quantum circuit that can be furthur compiled
+into pulses or other quantum instructions.
+
+# Supported Semantics
+
+- [`@ctrl`](@ref): Keyword for controlled gates in quantum circuit.
+- [`@measure`](@ref): Keyword for measurement in quantum circuit.
+
+The function marked by `@device` can be multiple dispatched like other Julia function. The only difference
+is that it always returns a quantum circuit object that should be runable on quantum device by feeding it
+the location of qubits and the pointer to quantum register.
+
+# Example
+
+We can define a Quantum Fourier Transformation in the following recursive way
+
+```julia
+@device function qft(n::Int)
+    1 => H
+    for k in 2:n
+        @ctrl k 1=>shift(2π/2^k)
+    end
+
+    if n > 1
+        2:n => qft(n-1)
+    end
+end
+```
+
+This will give us a generic quantum circuit `qft` with 1 method.
+"""
 macro device(ex)
     return esc(device_m(ex))
+end
+
+macro device(option, ex)
+    if (option isa Expr) && (option.head === :(=)) && (option.args[1] == :strict)
+        return esc(device_m(ex, true))
+    else
+        throw(Meta.ParseError("Invalid Syntax, expect a compile option"))
+    end
 end
 
 """
@@ -57,7 +100,7 @@ function rm_annotations(x::Expr)
     end
 end
 
-function device_m(ex::Expr)
+function device_m(ex::Expr, strict=false)
     def = splitdef(ex)
     haskey(def, :name) || throw(Meta.ParseError("Invalid Syntax: generic circuit should have a name"))
 
@@ -80,6 +123,10 @@ function device_m(ex::Expr)
     # splatting original classical arguments
     splat_args = Expr(:(=), free_args, :($stub_circ.free))
     ex = parse_ast(def[:body])
+
+    if strict && !(is_pure_quantum(ex))
+        throw(Meta.ParseError("statement is not a pure quantum program, move classical operations out of @device expression or use strict=false option"))
+    end
 
     stub_def = Dict{Symbol, Any}()
     stub_def[:name] = stub_name    


### PR DESCRIPTION
This is a very simple verifier to check if the user defines a pure quantum program. In the future, we should also actually check the variable types and its actual value to make sure it's a strictly pure quantum program via Cassette.