### PR TITLE
allow return classical value

### DIFF
--- a/src/compiler/compiler.jl
+++ b/src/compiler/compiler.jl
@@ -82,7 +82,7 @@ function codegen_quantum_circuit(ctx::JuliaASTCodegenCtx, ir::QASTCode)
     stub_def[:body] = quote
         $(splatting_variables(ir.free_variables, :($(ctx.circuit).free)))
         $(transform(ctx, ir.code))
-        return $(ctx.register)
+        return
     end
     return combinedef(stub_def)
 end
@@ -100,7 +100,7 @@ function codegen_ctrl_circuit(ctx::JuliaASTCodegenCtx, ir::QASTCode)
     stub_def[:body] = quote
         $(splatting_variables(ir.free_variables, :($(ctx.circuit).free)))
         $(ctrl_transform(ctx, ir.code))
-        return $(ctx.register)
+        return
     end
     return combinedef(stub_def)
 end

--- a/src/compiler/kwdefs.jl
+++ b/src/compiler/kwdefs.jl
@@ -4,8 +4,10 @@ export @device, @ctrl, @measure
     @device [strict=false] <generic circuit definition>
 
 Entry for defining a generic quantum program. A generic quantum program is a function takes
-a set of classical arguments as input and return a quantum circuit that can be furthur compiled
-into pulses or other quantum instructions.
+a set of classical arguments as input and return a quantum program that can be furthur compiled
+into pulses or other quantum instructions. The quantum program can return classical values from
+device if `return` statement is declared explicitly, or it always return nothing, and mutates the
+quantum register.
 
 # Supported Semantics
 

--- a/src/runtime/generic_circuit.jl
+++ b/src/runtime/generic_circuit.jl
@@ -49,6 +49,11 @@ end
 (circ::Circuit)(r::AbstractRegister) = circ(r, 1:nactive(r))
 (circ::Circuit)(locs) = Pair(locs, circ)
 
+function Base.:(|>)(r::AbstractRegister, circ::Circuit)
+    circ(r)
+    return r
+end
+
 # we only convert to Locations right before we call the stubs
 (circ::Circuit)(register, locs) = circ.fn(circ, register, Locations(locs))
 (circ::Circuit)(register, locs, ctrl_locs) =


### PR DESCRIPTION
The quantum program on device should be allowed to return classical value since the current default semantic of this DSL is modeling a host device contains the classical controller and quantum hardware. pipe operator is overloaded for convenience. This close #18 