### PR TITLE
disallow constants in pure quantum program

### DIFF
--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -27,6 +27,8 @@ function is_pure_quantum(ex::Expr)
     if ex.head === :call
         if ex.args[1] isa GlobalRef
             (ex.args[1].name in PRIMITIVES_GATE) && return true
+        elseif ex.args[1] isa Symbol # TODO: check metadata instead of hardcoded info
+            (ex.args[1] in PRIMITIVES_GATE) && return true
         elseif (ex.args[1] isa Expr)
             (ex.args[1].head === :(.)) &&
                 (ex.args[1].args[1] === :YaoLang) &&

--- a/src/compiler/validation.jl
+++ b/src/compiler/validation.jl
@@ -25,9 +25,7 @@ function is_pure_quantum(ex::Expr)
     ex.head === :quantum && return true
 
     if ex.head === :call
-        if ex.args[1] isa Symbol
-            return true
-        elseif ex.args[1] isa GlobalRef
+        if ex.args[1] isa GlobalRef
             (ex.args[1].name in PRIMITIVES_GATE) && return true
         elseif (ex.args[1] isa Expr)
             (ex.args[1].head === :(.)) &&

--- a/test/compiler/circuit.jl
+++ b/test/compiler/circuit.jl
@@ -31,16 +31,16 @@ end
 
 @device function qft4()
     1 => H
-    @ctrl 2 1 => shift(π / 2)
-    @ctrl 3 1 => shift(π / 4)
-    @ctrl 4 1 => shift(π / 8)
+    @ctrl 2 1 => shift($(π / 2))
+    @ctrl 3 1 => shift($(π / 4))
+    @ctrl 4 1 => shift($(π / 8))
 
     2 => H
-    @ctrl 3 2 => shift(π / 2)
-    @ctrl 4 2 => shift(π / 4)
+    @ctrl 3 2 => shift($(π / 2))
+    @ctrl 4 2 => shift($(π / 4))
 
     3 => H
-    @ctrl 4 3 => shift(π / 2)
+    @ctrl 4 3 => shift($(π / 2))
 
     4 => H
 end

--- a/test/compiler/validation.jl
+++ b/test/compiler/validation.jl
@@ -19,3 +19,15 @@ end)
     @test is_pure_quantum(ir) == false
     @test is_qasm_compatible(ir) == false
 end
+
+@testset "disallow constants" begin
+    ex = :(function circ()
+        1=>H
+        2=>Z
+        1 => shift(π/2)
+        3 => X
+        @ctrl 1 2=>X
+    end)
+    ir = YaoIR(@__MODULE__, ex)
+    @test is_pure_quantum(ir) == false
+end


### PR DESCRIPTION
This disallows constants (symbols in the IR) to be treated as constants since we don't actually have type inference here, thus we cannot be sure the symbol is a constant or not.