### PR TITLE
sink quantum statements in SSA block

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "YaoLang"
 uuid = "77e32715-2d53-453b-8330-e0520dba5551"
 authors = ["Roger-luo"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
@@ -13,7 +13,7 @@ YaoAPI = "0843a435-28de-4971-9e8b-a9641b2983a8"
 
 [compat]
 ExprTools = "0.1"
-IRTools = "0.3, 0.4"
+IRTools = "0.4"
 LuxurySparse = "0.6"
 TimerOutputs = "0.5"
 YaoAPI = "0.1"

--- a/src/YaoLang.jl
+++ b/src/YaoLang.jl
@@ -39,11 +39,8 @@ include("compiler/trace.jl")
 
 function __init__()
     TimerOutputs.reset_timer!(to)
-    # not sure why this doesn't work inside the module
-    IRTools.Inner.printers[:quantum] = function (io, ex)
-        get(printers, ex.args[1], print)(io, ex)
-    end
 end
+
 end
 
 using .Compiler

--- a/src/compiler/ir.jl
+++ b/src/compiler/ir.jl
@@ -15,6 +15,7 @@ mutable struct YaoIR
     args::Vector{Any}
     whereparams::Vector{Any}
     body::IR
+    quantum_blocks::Any # Vector{Tuple{Int, UnitRange{Int}}}
     pure_quantum::Bool
     qasm_compatible::Bool
 end
@@ -42,6 +43,7 @@ function YaoIR(m::Module, ast::Expr)
         get(defs, :args, Any[]),
         get(defs, :whereparams, Any[]),
         mark_quantum(body),
+        nothing,
         false,
         false,
     )
@@ -90,6 +92,14 @@ function update_slots!(ir::YaoIR)
         elseif (st.expr isa Symbol) && (st.expr in fn_args)
             ir.body[v] = Statement(st; expr = IRTools.Slot(st.expr))
         end
+    end
+    return ir
+end
+
+function sink_quantum!(ir::YaoIR)
+    deps = IRTools.dependencies(ir.body)
+    for (v, st) in ir.body
+        
     end
     return ir
 end

--- a/src/compiler/ir.jl
+++ b/src/compiler/ir.jl
@@ -47,11 +47,26 @@ function YaoIR(m::Module, ast::Expr)
         false,
         false,
     )
+    sink_quantum!(ir)
     update_slots!(ir)
+    ir.quantum_blocks = quantum_blocks(ir)
     return ir
 end
 
 YaoIR(ast::Expr) = YaoIR(@__MODULE__, ast)
+
+function Base.copy(ir::YaoIR)
+    YaoIR(
+        ir.mod,
+        ir.name isa Expr ? copy(ir.name) : ir.name ,
+        copy(ir.args),
+        copy(ir.whereparams),
+        copy(ir.body),
+        ir.quantum_blocks === nothing ? nothing : copy(ir.quantum_blocks),
+        ir.pure_quantum,
+        ir.qasm_compatible,
+    )
+end
 
 """
     mark_quantum(ir::IR)
@@ -97,9 +112,108 @@ function update_slots!(ir::YaoIR)
 end
 
 function sink_quantum!(ir::YaoIR)
-    deps = IRTools.dependencies(ir.body)
-    for (v, st) in ir.body
-        
+    ir_perms = []
+    for (k, b) in enumerate(blocks(ir.body))
+        perms = Variable[]
+        qstmts_tape = Variable[]
+        cstmts_tape = Variable[]
+
+        for (v, st) in b
+            if is_quantum(st)
+                if st.expr.args[1] === :measure
+                    append!(perms, cstmts_tape)
+                    append!(perms, qstmts_tape)
+                    push!(perms, v)
+
+                    empty!(cstmts_tape)
+                    empty!(qstmts_tape)
+                else
+                    push!(qstmts_tape, v)
+                end
+            else
+                push!(cstmts_tape, v)
+            end
+        end
+
+        append!(perms, cstmts_tape)
+        append!(perms, qstmts_tape)
+        push!(ir_perms, perms)
     end
+
+    ir.body = permute_stmts(ir.body, ir_perms)
     return ir
+end
+
+function permute_stmts(ir::IR, perms)
+    map = Dict()
+    count = 0
+    for pm in perms, v in pm
+        count += 1
+        map[v] = IRTools.var(count)
+    end
+
+    to = IR([],[], ir.lines, nothing)
+    for b in blocks(ir)
+        bb = BasicBlock(b)
+        push!(to.blocks, BasicBlock([], substitute(map, bb.args), bb.argtypes, substitute(map, bb.branches)))
+    end
+
+    for (b, pm) in zip(blocks(to), perms)
+        for v in pm
+            st = ir[v]
+            push!(b, Statement(st; expr=substitute(map, st.expr)))
+        end
+    end
+    return to
+end
+
+function substitute(d::Dict, ex)
+    if ex isa Expr
+        return Expr(ex.head, map(x->substitute(d, x), ex.args)...)
+    elseif ex isa Variable
+        return d[ex]
+    else
+        return ex
+    end
+end
+
+function substitute(d::Dict, ex::Vector)
+    return [substitute(d, x) for x in ex]
+end
+
+function substitute(d::Dict, ex::IRTools.Branch)
+    return IRTools.Branch(substitute(d, ex.condition), ex.block, substitute(d, ex.args))
+end
+
+function quantum_blocks(ir::YaoIR)
+    quantum_blocks = UnitRange{Int}[]
+
+    for b in blocks(ir.body)
+        start, stop = 0, 0
+        for (v, st) in b
+            if is_quantum(st)
+                if st.expr.args[1] === :measure
+                    push!(quantum_blocks, start:stop+1)
+                    start = stop = 0
+                else                
+                    if start > 0
+                        stop += 1
+                    else
+                        start = stop = v.id
+                    end
+                end
+            else
+                if start > 0
+                    push!(quantum_blocks, start:stop)
+                    start = stop = 0
+                end
+            end
+        end
+
+        if start > 0
+            push!(quantum_blocks, start:stop)
+        end
+    end
+
+    return quantum_blocks
 end

--- a/src/compiler/print.jl
+++ b/src/compiler/print.jl
@@ -54,8 +54,23 @@ function print_where(io::IO, whereparams::Vector{Any})
     print(io, "}")
 end
 
-const printers = Dict{Symbol,Any}()
-# modified show(io::IO, b::Block) from IRTools: print.jl
+Inner.print_stmt(io::IO, ::Val{:quantum}, ex) = print_quantum(io, Val(ex.args[1]), ex)
+
+print_quantum(io, ::Val, ex) = print(io, ex)
+print_quantum(io, ::Val{:gate}, ex) = print_quantum(io, ex)
+print_quantum(io, ::Val{:ctrl}, ex) = print_quantum(io, ex)
+print_quantum(io, ::Val{:measure}, ex) = print_quantum(io, ex)
+
+function print_quantum(io, ::Val{:register}, ex)
+    if ex.args[2] === :new
+        printstyled(io, "%new%"; color = :light_blue, bold = true)
+        print(io, "(", ex.args[3], ")")
+    elseif ex.args[2] === :prev
+        printstyled(io, "%prev%"; color = :light_blue, bold = true)
+    else
+        print(io, ex)
+    end
+end
 
 function print_quantum(io, ex)
     printstyled(io, ex.args[1]; color = :light_blue, bold = true)
@@ -67,18 +82,4 @@ function print_quantum(io, ex)
         print(io, each)
     end
     print(io, ")")
-end
-
-printers[:gate] = print_quantum
-printers[:ctrl] = print_quantum
-printers[:measure] = print_quantum
-printers[:register] = function print_register_meta(io, ex)
-    if ex.args[2] === :new
-        printstyled(io, "%new%"; color = :light_blue, bold = true)
-        print(io, "(", ex.args[3], ")")
-    elseif ex.args[2] === :prev
-        printstyled(io, "%prev%"; color = :light_blue, bold = true)
-    else
-        print(io, ex)
-    end
 end

--- a/src/compiler/trace.jl
+++ b/src/compiler/trace.jl
@@ -56,7 +56,7 @@ function YaoIR(m::Module, tape::TraceTape{1}, name = gensym())
         body = IR(lowered_ast.args[], 0)
     end
 
-    ir = YaoIR(m, name, Any[], Any[], mark_quantum(body), true, true)
+    ir = YaoIR(m, name, Any[], Any[], mark_quantum(body), nothing, true, true)
     update_slots!(ir)
     return ir
 end

--- a/test/compiler/circuit.jl
+++ b/test/compiler/circuit.jl
@@ -45,6 +45,22 @@ end
     4 => H
 end
 
+@device function qft4()
+    1 => H
+    @ctrl 2 1 => shift($(π / 2))
+    @ctrl 3 1 => shift($(π / 4))
+    @ctrl 4 1 => shift($(π / 8))
+
+    2 => H
+    @ctrl 3 2 => shift($(π / 2))
+    @ctrl 4 2 => shift($(π / 4))
+
+    3 => H
+    @ctrl 4 3 => shift($(π / 2))
+
+    4 => H
+end
+
 @device function hadamard()
     1 => H
 end
@@ -129,4 +145,18 @@ end
 @testset "purify" begin
     pure_qft = @quantum 3 qft(3)
     @test is_pure_quantum(@code_yao pure_qft())
+end
+
+@device function sink_quantum(θs)
+    for (k, θ) in enumerate(θs)
+        k => H
+        α = θ + 2π
+        k => Rz(sin(α))
+    end
+    return
+end
+
+@testset "sink quantum" begin
+    ir = @code_yao sink_quantum(rand(10))
+    @test ir.quantum_blocks == [6:6, 28:29]
 end


### PR DESCRIPTION
This PR lets YaoIR sink the quantum statements in each SSA block if the quantum statement is permutable with the following classical statements. This groups quantum statements into a larger contiguous statement which can be found in the new field `quantum_blocks`. The quantum blocks can then be further transformed as a whole pure quantum circuit component in the hybrid program (e.g circuit simplification pass)